### PR TITLE
this attribute needs to be lazy to properly access other attributes

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Release history for Dist-Zilla-Plugin-Git-Check-Remote
 
 {{$NEXT}}
+ - fix bug for when [Git::Remote::Check] is using all defaults (Karen
+   Etheridge)
 
 0.1.1 2011-10-15T02:53:58Z
  - First stable release, now fully documented.

--- a/lib/Dist/Zilla/Plugin/Git/Remote/Check.pm
+++ b/lib/Dist/Zilla/Plugin/Git/Remote/Check.pm
@@ -188,7 +188,7 @@ Defaults to C<5>
 
 with 'Dist::Zilla::Role::Git::Remote::Check';
 
-has '+_remote_branch' => ( default => sub { shift->branch } );
+has '+_remote_branch' => ( lazy => 1, default => sub { shift->branch } );
 
 __PACKAGE__->meta->make_immutable;
 no Moose;


### PR DESCRIPTION
...or this happens:

```
Attribute (_remote_branch) does not pass the type constraint because: Validation failed for 'Str' with value undef at constructor Dist::Zilla::Plugin::Git::Remote::Check::new (defined at /home/perlbrew/perls/perl-5.14.2/lib/site_perl/5.14.2/Dist/Zilla/Plugin/Git/Remote/Check.pm line 49) line 38
        Dist::Zilla::Plugin::Git::Remote::Check::new('Dist::Zilla::Plugin::Git::Remote::Check', 'HASH(0x5021520)') called at /home/perlbrew/perls/perl-5.14.2/lib/site_perl/5.14.2/Dist/Zilla/Role/Plugin.pm line 50
        Dist::Zilla::Role::Plugin::plugin_from_config('Dist::Zilla::Plugin::Git::Remote::Check', 'Git::Remote::Check', 'HASH(0x397f1e8)', 'Dist::Zilla::MVP::Section=HASH(0x4f43d08)') called at /home/perlbrew/perls/perl-5.14.2/lib/site_perl/5.14.2/Dist/Zilla/Role/Plugin.pm line 61
        Dist::Zilla::Role::Plugin::register_component('Dist::Zilla::Plugin::Git::Remote::Check', 'Git::Remote::Check', 'HASH(0x397f1e8)', 'Dist::Zilla::MVP::Section=HASH(0x4f43d08)') called at /home/perlbrew/perls/perl-5.14.2/lib/site_perl/5.14.2/Dist/Zilla/MVP/Section.pm line 48
...
```
